### PR TITLE
FIX: Failing tests due to i18n.default

### DIFF
--- a/test/javascripts/acceptance/translate-tag-test.js.es6
+++ b/test/javascripts/acceptance/translate-tag-test.js.es6
@@ -9,13 +9,13 @@ acceptance("Translated tags", function () {
 
   test("translates included data correctly", async (assert) => {
     I18n.locale = "fr";
-    assert.equal(I18n.default.currentLocale(), "fr");
+    assert.equal(I18n.currentLocale(), "fr");
     assert.equal(multilingualTagTranslator("motor-car"), "voiture");
   });
 
   test("doesn't translate tag when data does not include translation", async (assert) => {
     I18n.locale = "en";
-    assert.equal(I18n.default.currentLocale(), "en");
+    assert.equal(I18n.currentLocale(), "en");
     assert.equal(multilingualTagTranslator("motor-car"), "motor-car");
   });
 });


### PR DESCRIPTION
A simple fix to these test failures related https://github.com/discourse/discourse-multilingual/pull/1

```
Failures:

not ok 1 Chrome 118.0 - [204 ms] - Acceptance: Translated tags: doesn't translate tag when data does not include translation
    ---
        actual: >
            null
        stack: >
            TypeError: Cannot read properties of undefined (reading 'currentLocale')
                at Object.<anonymous> (http://localhost:7357/assets/plugins/test/discourse-multilingual_tests.js:120:42)
                at runTest (http://localhost:7357/assets/chunk.fee26945025bed3bf437.js:108305:35)
                at Test.run (http://localhost:7357/assets/chunk.fee26945025bed3bf437.js:108288:9)
                at http://localhost:7357/assets/chunk.fee26945025bed3bf437.js:108559:16
                at processTaskQueue (http://localhost:7357/assets/chunk.fee26945025bed3bf437.js:107881:26)
                at advanceTaskQueue (http://localhost:7357/assets/chunk.fee26945025bed3bf437.js:107864:5)
                at Object.advance (http://localhost:7357/assets/chunk.fee26945025bed3bf437.js:107852:5)
                at http://localhost:7357/assets/chunk.fee26945025bed3bf437.js:109024:25
        message: >
            Promise rejected during "doesn't translate tag when data does not include translation": Cannot read properties of undefined (reading 'currentLocale')
        negative: >
            false
        browser log: |
    ...
not ok 6 Chrome 118.0 - [56 ms] - Acceptance: Translated tags: translates included data correctly
    ---
        actual: >
            null
        stack: >
            TypeError: Cannot read properties of undefined (reading 'currentLocale')
                at Object.<anonymous> (http://localhost:7357/assets/plugins/test/discourse-multilingual_tests.js:115:42)
                at runTest (http://localhost:7357/assets/chunk.fee26945025bed3bf437.js:108305:35)
                at Test.run (http://localhost:7357/assets/chunk.fee26945025bed3bf437.js:108288:9)
                at http://localhost:7357/assets/chunk.fee26945025bed3bf437.js:108559:16
                at processTaskQueue (http://localhost:7357/assets/chunk.fee26945025bed3bf437.js:107881:26)
                at advanceTaskQueue (http://localhost:7357/assets/chunk.fee26945025bed3bf437.js:107864:5)
                at Object.advance (http://localhost:7357/assets/chunk.fee26945025bed3bf437.js:107852:5)
                at http://localhost:7357/assets/chunk.fee26945025bed3bf437.js:109024:25
        message: >
            Promise rejected during "translates included data correctly": Cannot read properties of undefined (reading 'currentLocale')
        negative: >
            false
        browser log: |
    ...
Testem finished with non-zero exit code. Tests failed.
```

