### PR TITLE
DEV: Resolve link-to.positional-arguments deprecation

### DIFF
--- a/assets/javascripts/discourse/templates/components/admin-language.hbs
+++ b/assets/javascripts/discourse/templates/components/admin-language.hbs
@@ -13,7 +13,7 @@
 <td class={{contentClass}}>
   {{#if contentDisabled}}
     {{#if language.content_tag_conflict}}
-      {{#link-to "tag.show" language.locale}}
+      {{#link-to route="tag.show" model=language.locale}}
         {{d-icon "warning"}}
         <span>{{i18n "multilingual.languages.content_tag_conflict" tagName=language.locale}}</span>
       {{/link-to}}

--- a/test/javascripts/acceptance/content-languages-dropdown-test.js.es6
+++ b/test/javascripts/acceptance/content-languages-dropdown-test.js.es6
@@ -44,19 +44,18 @@ acceptance(
 
       assert.ok(exists(".content-languages-dropdown"), "displays");
 
-      assert.equal(
-        find(".content-languages-dropdown summary").hasClass("has-languages"),
-        true,
-        "has content languages"
-      );
+      assert
+        .dom(".content-languages-dropdown summary")
+        .hasClass("has-languages", "has content languages");
 
       await click(".content-languages-dropdown summary");
 
-      assert.equal(
-        find(".content-languages-dropdown .select-kit-collection li").length,
-        2,
-        "should render content languages and the set languages link"
-      );
+      assert
+        .dom(".content-languages-dropdown .select-kit-collection li")
+        .exists(
+          { count: 2 },
+          "should render content languages and the set languages link"
+        );
     });
   }
 );

--- a/test/javascripts/acceptance/content-languages-tags-test.js.es6
+++ b/test/javascripts/acceptance/content-languages-tags-test.js.es6
@@ -20,9 +20,6 @@ acceptance("Content language tags", function (needs) {
 
   test("displays content language tags correctly", async (assert) => {
     await visit("/");
-    assert.equal(
-      find(`.content-language-tags .discourse-tag:eq(0)`).text(),
-      "Qafár af"
-    );
+    assert.dom(`.content-language-tags .discourse-tag`).hasText("Qafár af");
   });
 });

--- a/test/javascripts/acceptance/content-languages-user-preferences-test.js.es6
+++ b/test/javascripts/acceptance/content-languages-user-preferences-test.js.es6
@@ -47,11 +47,9 @@ acceptance(
 
       await click(".content-languages-selector summary");
 
-      assert.equal(
-        find(".content-languages-selector .select-kit-collection li").length,
-        2,
-        "displays the content languages"
-      );
+      assert
+        .dom(".content-languages-selector .select-kit-collection li")
+        .exists({ count: 2 }, "displays the content languages");
     });
   }
 );


### PR DESCRIPTION
https://deprecations.emberjs.com/v3.x#toc_ember-glimmer-link-to-positional-arguments

This deprecation happens at build-time, which means it doesn't get surfaced like other deprecations in Discourse themes/plugins.