### PR TITLE
DEV: Refresh auto groups in tests to make them pass

### DIFF
--- a/spec/components/topic_creator_spec.rb
+++ b/spec/components/topic_creator_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../plugin_helper"
 
 describe TopicCreator do
-  fab!(:staff) { Fabricate(:moderator) }
+  fab!(:staff) { Fabricate(:moderator, refresh_auto_groups: true) }
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:tag) { Fabricate(:tag) }
 


### PR DESCRIPTION
### What is this change?

We changed our access settings to be based on group membership rather than TL column. This requires some tests to refresh the group memberships to have the tests keep passing.