### PR TITLE
DEV: Refactor for core changes

### DIFF
--- a/lib/multilingual/locale_loader.rb
+++ b/lib/multilingual/locale_loader.rb
@@ -1,19 +1,17 @@
 # frozen_string_literal: true
 class ::Multilingual::LocaleLoader
-  include ::ApplicationHelper
+  attr_reader :controller
 
-  attr_reader :ctx
-
-  def initialize(ctx)
-    @ctx = ctx
+  def initialize(controller)
+    @controller = controller
   end
 
   def request
-    @ctx && @ctx.request ? @ctx.request : ActionDispatch::Request.new
+    @controller.request
   end
 
   def asset_path(url)
-    ActionController::Base.helpers.asset_path(url)
+    @controller.helpers.asset_path(url)
   end
 
   def current_locale
@@ -25,14 +23,14 @@ class ::Multilingual::LocaleLoader
   end
 
   def preload_i18n
-    preload_script("locales/i18n")
+    @controller.helpers.preload_script("locales/i18n")
   end
 
   def preload_custom_locale
-    preload_script_url(ExtraLocalesController.url('custom-language'))
+    @controller.helpers.preload_script_url(ExtraLocalesController.url("custom-language"))
   end
 
   def preload_tag_translations
-    preload_script_url(ExtraLocalesController.url('tags'))
+    @controller.helpers.preload_script_url(ExtraLocalesController.url("tags"))
   end
 end

--- a/lib/multilingual/locale_loader.rb
+++ b/lib/multilingual/locale_loader.rb
@@ -2,16 +2,12 @@
 class ::Multilingual::LocaleLoader
   attr_reader :controller
 
+  delegate :request, to: :controller
+  delegate :helpers, to: :controller, private: true
+  delegate :asset_path, to: :helpers
+
   def initialize(controller)
     @controller = controller
-  end
-
-  def request
-    @controller.request
-  end
-
-  def asset_path(url)
-    @controller.helpers.asset_path(url)
   end
 
   def current_locale
@@ -23,14 +19,14 @@ class ::Multilingual::LocaleLoader
   end
 
   def preload_i18n
-    @controller.helpers.preload_script("locales/i18n")
+    helpers.preload_script("locales/i18n")
   end
 
   def preload_custom_locale
-    @controller.helpers.preload_script_url(ExtraLocalesController.url("custom-language"))
+    helpers.preload_script_url(ExtraLocalesController.url("custom-language"))
   end
 
   def preload_tag_translations
-    @controller.helpers.preload_script_url(ExtraLocalesController.url("tags"))
+    helpers.preload_script_url(ExtraLocalesController.url("tags"))
   end
 end


### PR DESCRIPTION
Core's script helper methods expect to be run in the context of a controller, with access to the response property. This is especially important now that core is applying a CSP nonce to every `<script>`.