### PR TITLE
FIX: prevents test failure

### DIFF
--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -4,12 +4,11 @@
 require 'webmock/rspec'
 
 RSpec.configure do |config|
-  config.around(:each) do |example|
-    ActiveRecord::Base.transaction do
-      example.run
-      raise ActiveRecord::Rollback
-    end
-  end
+  config.before(:each) { ActiveRecord::Base.connection.begin_transaction(joinable: false) }
+
+  config.after(:each) { ActiveRecord::Base.connection.rollback_transaction }
+
+  config.around(:each) { |example| allow_missing_translations { example.run } }
 end
 
 require 'rails_helper'


### PR DESCRIPTION
This commit is fixing two failures:
- nested transaction due to old rollback code
- the new exception on translation missing causing failure (Translation missing: en.views.mountain), for this plugin it seems sage to always ignore missing translations in tests