### PR TITLE
FIX: correctly set type/code on serialize

### DIFF
--- a/app/models/multilingual/custom_translation.rb
+++ b/app/models/multilingual/custom_translation.rb
@@ -6,7 +6,7 @@ class Multilingual::CustomTranslation < ActiveRecord::Base
   KEY ||= 'file'.freeze
 
   validates :file_name, :locale, :file_type, :file_ext, :translation_data, presence: true
-  serialize :translation_data
+  serialize :translation_data, type: Hash, coder: YAML
   before_save :process_file
   after_save :after_save
 


### PR DESCRIPTION
This was causing this error:

```
 `serialize': missing keyword: :coder If no default coder is configured, a coder must be provided to `serialize`. (ArgumentError)

            raise ArgumentError, <<~MSG.squish
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This is related to rails 7.1 updated: https://github.com/discourse/discourse/commit/84823550d48a730a8ee1922e5f2e7565435a422e